### PR TITLE
Avoid double-counting rewards on sell

### DIFF
--- a/freqtradegym.py
+++ b/freqtradegym.py
@@ -87,6 +87,7 @@ class TradingEnv(gym.Env):
 
         self.observation_space = spaces.Box(
             low=np.full(24, -np.inf), high=np.full(24, np.inf), dtype=np.float)
+        self.last_profit_ratio = 0.0
 
     def _next_observation(self):    
         row = self.ticker[self.index]
@@ -179,6 +180,7 @@ class TradingEnv(gym.Env):
                     "type": 'buy',
                     "total": self.status.open
                 })
+                self.last_profit_ratio = 0.0
 
                 logger.debug("{} - Backtesting emulates creation of new trade: {}.".format(
                     self.pair, self.trade))
@@ -190,7 +192,8 @@ class TradingEnv(gym.Env):
                 profit_abs = self.trade.calc_profit(rate=self.status.open)
                 self.money += profit_abs
                 self.trade = None
-                self._reward = profit_percent
+                self._reward = profit_percent - self.last_profit_ratio
+                self.last_profit_ratio = 0.0
 
                 self.trades.append({
                     "step": self.index,
@@ -204,19 +207,31 @@ class TradingEnv(gym.Env):
         self._take_action(action)
 
         self.index += 1
-        if self._reward > 1.5:
-            self._reward = 0
 
+        done = False
         if self.index >= len(self.ticker):
-            self.index = 0
+            self.index = len(self.ticker) - 1
+            done = True
 
         self.steps += 1
+
+        if self._reward == 0 and not done:
+            row = self.ticker[self.index]
+            if self.trade is not None:
+                profit_ratio = self.trade.calc_profit_ratio(rate=row.open)
+                self._reward = profit_ratio - self.last_profit_ratio
+                self.last_profit_ratio = profit_ratio
+            else:
+                self._reward = -self.reward_decay
+
+        if done and self.trade is not None:
+            self._reward -= self.not_complete_trade_decay
 
         self.total_reward += self._reward
 
         # done = (self._reward < self.game_loss) # or (self.steps > self.day_step)
         # done = (self.total_reward < self.game_loss) or (self.total_reward > self.game_win) or (self.steps > self.day_step)
-        done = self.steps > self.simulate_length     
+        done = done or self.steps > self.simulate_length
 
         obs = self._next_observation()
 
@@ -233,6 +248,7 @@ class TradingEnv(gym.Env):
         self._reward = 0
         self.total_reward = 0
         self.money = 0
+        self.last_profit_ratio = 0.0
 
         self.visualization = None        
 


### PR DESCRIPTION
### Motivation
- Prevent double-counting realized profit on `sell` when unrealized per-step rewards are already credited.
- Provide a denser per-step reward signal for open positions using incremental profit changes.
- Make episode termination deterministic by clamping `index` at the end of the dataset and marking `done`.
- Discourage idleness and unfinished trades by applying small step penalties and end-of-episode decay.

### Description
- Compute sell rewards as `profit_percent - self.last_profit_ratio` and reset `self.last_profit_ratio` to `0.0` on `sell` to avoid double-counting.
- Initialize and reset `self.last_profit_ratio = 0.0` in the environment constructor and `reset`, and set it on `buy` events.
- Add per-step reward updates so that when `_reward == 0` and not `done` the env applies `profit_ratio - last_profit_ratio` for open trades (and updates `last_profit_ratio`) or `-reward_decay` when idle.
- Clamp `index` to `len(self.ticker) - 1` and set `done = True` at dataset end, and apply `-not_complete_trade_decay` to `_reward` if a trade is still open at episode end.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f6d3dbc0c83268fa0d2862ccc3ab9)